### PR TITLE
NameError: name 'os' is not defined

### DIFF
--- a/qgreports/qualys_connector.py
+++ b/qgreports/qualys_connector.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import sys
 import xml.etree.ElementTree as ET


### PR DESCRIPTION
/usr/local/bin/runreports.sh
Getting reports
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/qgreports/scripts/get_reports.py", line 5, in <module>
    import qgreports.qualys_connector as qc
  File "/usr/local/lib/python2.7/dist-packages/qgreports/qualys_connector.py", line 18, in <module>
    logging.config.fileConfig(os.path.join(os.path.dirname(qgreports.config.**file**),
NameError: name 'os' is not defined
